### PR TITLE
Add support for QR codes in XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The following example is self-explanatory:
         <barcode encoding='ean13'>
             5449000000996
         </barcode>
+        <qr>
+            QR code text goes here.
+        </qr>
         <cashdraw /> 
         <cut />
     </receipt>
@@ -102,6 +105,13 @@ supported: `UPC-A`,`UPC-E`,`EAN13`,`EAN8`,`CODE39`,`ITF`,`NW7`.
     <barcode encoding="EAN13">
         5400113509509
     </barcode>
+
+### QR code Tags
+It is possible to include QR codes in your receipt with the `qr tag`.
+
+    <qr>
+        QR code text goes here.
+    </qr>
 
 ### Line Tag
 The `line` tag is used to quickly layout receipt lines. Its child elements

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    install_requires=['pyusb'],
+    install_requires=['pyusb', 'qrcode'],
 
     # List additional groups of dependencies here (e.g. development dependencies).
     # You can install these using the following syntax, for example:

--- a/test_printer.py
+++ b/test_printer.py
@@ -14,7 +14,10 @@ test_temp = """
         <barcode encoding='ean13'>
             5449000000996
         </barcode>
-        <cashdraw /> 
+        <qr>
+            QR code text goes here.
+        </qr>
+        <cashdraw />
         <cut />
     </receipt>
 """
@@ -32,7 +35,7 @@ try:
     printer._raw('\x1D\x28\x47\x02\x00\x30\x04');
     printer._raw('AAAA');
     printer._raw('\x0c');
-    
+
     printer._raw('\x1c\x61\x31');
     printer._raw('BBBB');
     printer._raw('\x0c');

--- a/xmlescpos/escpos.py
+++ b/xmlescpos/escpos.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     jcconv = None
 
-try: 
+try:
     import qrcode
 except ImportError:
     qrcode = None
@@ -466,7 +466,7 @@ class Escpos:
 
     def qr(self,text):
         """ Print QR Code for the provided string """
-        qr_code = qrcode.QRCode(version=4, box_size=4, border=1)
+        qr_code = qrcode.QRCode(version=4, box_size=6, border=1)
         qr_code.add_data(text)
         qr_code.make(fit=True)
         qr_img = qr_code.make_image()
@@ -474,6 +474,8 @@ class Escpos:
 
         # Convert the RGB image in printable image
         pix_line, img_size = self._convert_image(im)
+        # Center the barcode
+        self._raw(TXT_ALIGN_CT)
         # Print the image
         self._print_image(pix_line, img_size)
 

--- a/xmlescpos/escpos.py
+++ b/xmlescpos/escpos.py
@@ -471,8 +471,11 @@ class Escpos:
         qr_code.make(fit=True)
         qr_img = qr_code.make_image()
         im = qr_img._img.convert("RGB")
+
         # Convert the RGB image in printable image
-        self._convert_image(im)
+        pix_line, img_size = self._convert_image(im)
+        # Print the image
+        self._print_image(pix_line, img_size)
 
     def barcode(self, code, bc, width=255, height=2, pos='below', font='a'):
         """ Print Barcode """
@@ -678,6 +681,11 @@ class Escpos:
             elif elem.tag == 'barcode' and 'encoding' in elem.attrib:
                 serializer.start_block(stylestack)
                 self.barcode(strclean(elem.text),elem.attrib['encoding'])
+                serializer.end_entity()
+
+            elif elem.tag == 'qr':
+                serializer.start_block(stylestack)
+                self.qr(strclean(elem.text))
                 serializer.end_entity()
 
             elif elem.tag == 'cut':

--- a/xmlescpos/escpos.py
+++ b/xmlescpos/escpos.py
@@ -709,6 +709,7 @@ class Escpos:
                 self.slip_sheet_mode = True
             else:
                 self._raw(SHEET_ROLL_MODE)
+                self.slip_sheet_mode = False
 
             self._raw(stylestack.to_escpos())
 


### PR DESCRIPTION
I've added support for QR codes, since the initial code didn't seem to have it implemented completely. QR codes now work a lot like barcodes, meaning the `qr` function also prints them, and you can use the `<qr>text</qr>` tag in XML.
