### PR TITLE
Add DESCRIPTION.rst and other files to package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include DESCRIPTION.rst
+include LICENSE.txt
+include README.md


### PR DESCRIPTION
DESCRIPTION.rst is required to be packaged because setup.py read it to
set the long_description.
Other files LICENSE.txt and README.md are always good to have in the
package.
