### PR TITLE
Fix AttributeError due to slip_sheet_mode being undefined

### DIFF
--- a/xmlescpos/escpos.py
+++ b/xmlescpos/escpos.py
@@ -699,6 +699,7 @@ class Escpos:
                 self.slip_sheet_mode = True
             else:
                 self._raw(SHEET_ROLL_MODE)
+                self.slip_sheet_mode = False
 
             self._raw(stylestack.to_escpos())
 


### PR DESCRIPTION
If slip sheet mode is not enabled, `Escpos.slip_sheet_mode` is undefined, which leads to an attribute error in escpos.py#712
