### PR TITLE
Use python logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,29 @@ any element.
 - `tabwidth`: The number of spaces in a single indentation level (default 2)
 - `color` : `black` or `red` 
 
+## Logging
+
+This library uses Python's [builtin logging module](https://docs.python.org/2/library/logging.html)
+to log exceptions, errors, warnings and informational messages. To simply get all logging information 
+printed to `stdout` for easier debugging, just add the following code before your `main()` function:
+
+    import logging
+    LOG_LEVEL = logging.DEBUG
+    
+    # set up stdout logging handler
+    out_hdlr = logging.StreamHandler(sys.stdout)
+    out_hdlr.setFormatter(logging.Formatter('%(asctime)s [%(module)s] %(message)s'))
+    out_hdlr.setLevel(LOG_LEVEL)
+    
+    # use stdout logging handler
+    log.addHandler(out_hdlr)
+    log.setLevel(LOG_LEVEL)
+    
+    # ...
+    
+    def main():
+        # add some code here which uses this great library ;)
+        # ...
+        
+    if __name__ == "__main__":
+        main()

--- a/xmlescpos/printer.py
+++ b/xmlescpos/printer.py
@@ -4,11 +4,15 @@ import usb.core
 import usb.util
 import serial
 import socket
+import logging
 
 from escpos import *
 from constants import *
 from exceptions import *
 from time import sleep
+
+log = logging.getLogger(__name__)
+
 
 class Usb(Escpos):
     """ Define USB printer """
@@ -153,9 +157,9 @@ class Serial(Escpos):
         self.device = serial.Serial(port=self.devfile, baudrate=self.baudrate, bytesize=self.bytesize, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, timeout=self.timeout, dsrdtr=True)
 
         if self.device is not None:
-            print "Serial printer enabled"
+            log.info("Serial printer enabled")
         else:
-            print "Unable to open serial printer on: %s" % self.devfile
+            log.error("Unable to open serial printer on: %s" % self.devfile)
 
 
     def _raw(self, msg):
@@ -189,7 +193,7 @@ class Network(Escpos):
         self.device.connect((self.host, self.port))
 
         if self.device is None:
-            print "Could not open socket for %s" % self.host
+            log.error("Could not open socket for %s" % self.host)
 
 
     def _raw(self, msg):


### PR DESCRIPTION
Using Python's builtin logging module is better than calling `print`, and it is much better than printing stacktraces on the device ;)
