### PR TITLE
Compatibility fix for Windows

### DIFF
--- a/xmlescpos/printer.py
+++ b/xmlescpos/printer.py
@@ -46,7 +46,7 @@ class Usb(Escpos):
 
     def close(self):
         i = 0
-        while True:
+        while self.device:
             try:
                 usb.util.release_interface(self.device, self.interface)
                 self._reattach_kernel_driver()


### PR DESCRIPTION
Since Windows has a different driver concept, `is_kernel_driver_active()` is not necessary there and raises an `NotImplementedError`.

The patch catches and ignores this error, so we can use xmlescpos on Windows, too.
