### PR TITLE
[FIX] RGB/RGBA image error

### DIFF
--- a/xmlescpos/escpos.py
+++ b/xmlescpos/escpos.py
@@ -444,9 +444,9 @@ class Escpos:
             f.seek(0)
             img_rgba = Image.open(f)
             img = Image.new('RGB', img_rgba.size, (255,255,255))
-            channels = img_rgba.split()
-            if len(channels) > 1:
+            if img_rgba.mode == 'RGBA':
                 # use alpha channel as mask
+                channels = img_rgba.split()
                 img.paste(img_rgba, mask=channels[3])
             else:
                 img.paste(img_rgba)


### PR DESCRIPTION
If an image with only RGB channels (no alpha channel) is printed an "IndexError" expception is raised
because the index 3 is invalid for invalid for an image with only 3 channels like RGB image.
This fix merely used the information provided by the "mode" property of the PIL "Image" object.